### PR TITLE
remove property to configure class use as jsonschema

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,11 @@
             <artifactId>printables-core</artifactId>
             <version>${ddd.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.github.sebastian-toepfer.json-schema</groupId>
+            <artifactId>json-schema-api</artifactId>
+            <version>0.1.1</version>
+        </dependency>
 
         <dependency>
             <groupId>org.eclipse.parsson</groupId>
@@ -128,11 +133,6 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.github.sebastian-toepfer.json-schema</groupId>
-            <artifactId>json-schema-api</artifactId>
-            <version>0.1.1</version>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/src/main/java/io/github/sebastiantoepfer/json/rpc/maven/json/printable/plugin/GenerateMojo.java
+++ b/src/main/java/io/github/sebastiantoepfer/json/rpc/maven/json/printable/plugin/GenerateMojo.java
@@ -51,9 +51,6 @@ public class GenerateMojo extends AbstractMojo {
     @Parameter(required = true)
     private String packageName;
 
-    @Parameter(required = true)
-    private String jsonSchemaClassName;
-
     @Parameter
     private URL schemaUrl;
 
@@ -65,7 +62,7 @@ public class GenerateMojo extends AbstractMojo {
         getLog().debug("> execute");
         try {
             new CodeGenerator(
-                new ModelCreator(new JsonSchemaProvider(schemaUrl), new JsonTypeToJavaTypeMapping(jsonSchemaClassName)),
+                new ModelCreator(new JsonSchemaProvider(schemaUrl), new JsonTypeToJavaTypeMapping()),
                 packageName,
                 new Templates(new JavaClassOutput(sourceDestDir.toPath()))
             )

--- a/src/main/java/io/github/sebastiantoepfer/json/rpc/maven/json/printable/plugin/model/JsonTypeToJavaTypeMapping.java
+++ b/src/main/java/io/github/sebastiantoepfer/json/rpc/maven/json/printable/plugin/model/JsonTypeToJavaTypeMapping.java
@@ -25,6 +25,7 @@ package io.github.sebastiantoepfer.json.rpc.maven.json.printable.plugin.model;
 
 import io.github.sebastiantoepfer.ddd.common.Printable;
 import io.github.sebastiantoepfer.json.rpc.maven.json.printable.plugin.utils.FirstCharToUpperCase;
+import io.github.sebastiantoepfer.jsonschema.JsonSchema;
 import jakarta.json.JsonObject;
 import java.net.URL;
 import java.util.Collection;
@@ -38,7 +39,7 @@ public final class JsonTypeToJavaTypeMapping implements TypeRegistry {
 
     private final Map<String, ClassType> jsonToJava;
 
-    public JsonTypeToJavaTypeMapping(final String schemaClassName) {
+    public JsonTypeToJavaTypeMapping() {
         this.jsonToJava =
             Map.ofEntries(
                 Map.entry("integer", new ClassType(long.class.getSimpleName(), false)),
@@ -49,7 +50,7 @@ public final class JsonTypeToJavaTypeMapping implements TypeRegistry {
                 Map.entry("$ref", new ClassType(String.class.getSimpleName())),
                 Map.entry(
                     "JSONSchema",
-                    new ClassType(schemaClassName.substring(schemaClassName.lastIndexOf(".") + 1), schemaClassName)
+                    new ClassType(JsonSchema.class.getSimpleName(), JsonSchema.class.getCanonicalName())
                 )
             );
     }

--- a/src/test/java/io/github/sebastiantoepfer/json/rpc/maven/json/printable/plugin/AlternativeJsonObjectClassWriterTest.java
+++ b/src/test/java/io/github/sebastiantoepfer/json/rpc/maven/json/printable/plugin/AlternativeJsonObjectClassWriterTest.java
@@ -27,7 +27,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 import io.github.sebastiantoepfer.json.rpc.maven.json.printable.plugin.model.JsonTypeToJavaTypeMapping;
-import io.github.sebastiantoepfer.jsonschema.JsonSchema;
 import java.io.IOException;
 import java.io.StringWriter;
 import org.junit.jupiter.api.Test;
@@ -91,7 +90,7 @@ class AlternativeJsonObjectClassWriterTest {
     private String generateOpenRPCSpecClassWithName(final String clsName) throws IOException {
         final StringWriter writer = new StringWriter();
         new CodeGenerator(
-            new ModelCreator(new JsonSchemaProvider(), new JsonTypeToJavaTypeMapping(JsonSchema.class.getName())),
+            new ModelCreator(new JsonSchemaProvider(), new JsonTypeToJavaTypeMapping()),
             "io.github",
             new Templates(new FilteredClassOutput(clsName, writer))
         )

--- a/src/test/java/io/github/sebastiantoepfer/json/rpc/maven/json/printable/plugin/DefaultJsonObjectClassWriterTest.java
+++ b/src/test/java/io/github/sebastiantoepfer/json/rpc/maven/json/printable/plugin/DefaultJsonObjectClassWriterTest.java
@@ -27,7 +27,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 import io.github.sebastiantoepfer.json.rpc.maven.json.printable.plugin.model.JsonTypeToJavaTypeMapping;
-import io.github.sebastiantoepfer.jsonschema.JsonSchema;
 import java.io.IOException;
 import java.io.StringWriter;
 import org.junit.jupiter.api.Test;
@@ -283,7 +282,7 @@ class DefaultJsonObjectClassWriterTest {
     private String generateOpenRPCSpecClassWithName(final String clsName) throws IOException {
         final StringWriter writer = new StringWriter();
         new CodeGenerator(
-            new ModelCreator(new JsonSchemaProvider(), new JsonTypeToJavaTypeMapping(JsonSchema.class.getName())),
+            new ModelCreator(new JsonSchemaProvider(), new JsonTypeToJavaTypeMapping()),
             "io.github",
             new Templates(new FilteredClassOutput(clsName, writer))
         )


### PR DESCRIPTION
use JSON schema from JSON-schema lib instead. it means we no longer must create a class that represents our schema.

closes #60 