### PR TITLE
consolidate alternatives

### DIFF
--- a/src/main/java/io/github/sebastiantoepfer/json/rpc/maven/json/printable/plugin/model/ParameterAlternatives.java
+++ b/src/main/java/io/github/sebastiantoepfer/json/rpc/maven/json/printable/plugin/model/ParameterAlternatives.java
@@ -28,7 +28,6 @@ import static java.util.stream.Collectors.toCollection;
 
 import io.github.sebastiantoepfer.ddd.common.Media;
 import io.github.sebastiantoepfer.ddd.common.Printable;
-import io.github.sebastiantoepfer.json.rpc.maven.json.printable.plugin.utils.FirstCharToUpperCase;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonValue;
@@ -37,6 +36,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 import javax.annotation.processing.Generated;
 
 public final class ParameterAlternatives implements JsonObjectClassDefinition {
@@ -86,7 +86,19 @@ public final class ParameterAlternatives implements JsonObjectClassDefinition {
 
     @Override
     public String objectname() {
-        return new FirstCharToUpperCase(parent.name()).toCase();
+        return alternatives()
+            .stream()
+            .map(ParameterAlternative::type)
+            .map(name -> {
+                final String result;
+                if (name.endsWith("Object")) {
+                    result = name.substring(0, name.length() - "Object".length());
+                } else {
+                    result = name;
+                }
+                return result;
+            })
+            .collect(Collectors.joining("Or"));
     }
 
     @Override

--- a/src/main/java/io/github/sebastiantoepfer/json/rpc/maven/json/printable/plugin/model/Property.java
+++ b/src/main/java/io/github/sebastiantoepfer/json/rpc/maven/json/printable/plugin/model/Property.java
@@ -148,7 +148,14 @@ public final class Property implements Typeable {
 
     @Override
     public String type() {
-        return jsonTypeToJavaTypeMapping.resolveFor(json.getValue().asJsonObject()).resolveType();
+        final String result;
+        final ParameterAlternatives alternative = alternatives();
+        if (isArray() || alternative == null) {
+            result = jsonTypeToJavaTypeMapping.resolveFor(json.getValue().asJsonObject()).resolveType();
+        } else {
+            result = alternative.objectname();
+        }
+        return result;
     }
 
     @Override

--- a/src/test/java/io/github/sebastiantoepfer/json/rpc/maven/json/printable/plugin/DefaultJsonObjectClassWriterTest.java
+++ b/src/test/java/io/github/sebastiantoepfer/json/rpc/maven/json/printable/plugin/DefaultJsonObjectClassWriterTest.java
@@ -279,6 +279,114 @@ class DefaultJsonObjectClassWriterTest {
         );
     }
 
+    @Test
+    void should_generate_javaclass_with_or_parameters() throws Exception {
+        assertThat(
+            generateOpenRPCSpecClassWithName("MethodObject"),
+            is(
+                """
+                package io.github;
+
+                import io.github.sebastiantoepfer.ddd.common.Media;
+                import io.github.sebastiantoepfer.ddd.common.Printable;
+                import io.github.sebastiantoepfer.ddd.printables.core.CompositePrintable;
+                import io.github.sebastiantoepfer.ddd.printables.core.NamedBooleanPrintable;
+                import io.github.sebastiantoepfer.ddd.printables.core.NamedListPrintable;
+                import io.github.sebastiantoepfer.ddd.printables.core.NamedPrintable;
+                import io.github.sebastiantoepfer.ddd.printables.core.NamedStringPrintable;
+                import java.util.List;
+                import java.util.Objects;
+                import javax.annotation.processing.Generated;
+
+                @Generated("jsongen")
+                public final class MethodObject implements Printable {
+
+                    private final CompositePrintable values;
+
+                    public MethodObject(final String name, final List<ContentDescriptorOrReference> params) {
+                        this(
+                            new CompositePrintable()
+                                .withPrintable(new NamedStringPrintable("name", Objects.requireNonNull(name)))
+                                .withPrintable(new NamedListPrintable("params", Objects.requireNonNull(params)))
+                        );
+                    }
+
+                    private MethodObject(final CompositePrintable values) {
+                        this.values = Objects.requireNonNull(values);
+                    }
+
+                    public MethodObject withDescription(final String description) {
+                        return new MethodObject(values.withPrintable(new NamedStringPrintable("description", description)));
+                    }
+
+                    public MethodObject withSummary(final String summary) {
+                        return new MethodObject(values.withPrintable(new NamedStringPrintable("summary", summary)));
+                    }
+
+                    public MethodObject withServers(final List<ServerObject> servers) {
+                        return new MethodObject(values.withPrintable(new NamedListPrintable("servers", servers)));
+                    }
+
+                    public MethodObject withTags(final List<TagOrReference> tags) {
+                        return new MethodObject(values.withPrintable(new NamedListPrintable("tags", tags)));
+                    }
+
+                    public MethodObject withParamStructure(final MethodObjectParamStructure paramStructure) {
+                        return new MethodObject(values.withPrintable(new NamedStringPrintable("paramStructure", paramStructure.toString())));
+                    }
+
+                    public MethodObject withResult(final ContentDescriptorOrReference result) {
+                        return new MethodObject(values.withPrintable(new NamedPrintable("result", result)));
+                    }
+
+                    public MethodObject withErrors(final List<ErrorOrReference> errors) {
+                        return new MethodObject(values.withPrintable(new NamedListPrintable("errors", errors)));
+                    }
+
+                    public MethodObject withLinks(final List<LinkOrReference> links) {
+                        return new MethodObject(values.withPrintable(new NamedListPrintable("links", links)));
+                    }
+
+                    public MethodObject withExamples(final List<ExamplePairingOrReference> examples) {
+                        return new MethodObject(values.withPrintable(new NamedListPrintable("examples", examples)));
+                    }
+
+                    public MethodObject withDeprecated(final boolean deprecated) {
+                        return new MethodObject(values.withPrintable(new NamedBooleanPrintable("deprecated", deprecated)));
+                    }
+
+                    public MethodObject withExternalDocs(final ExternalDocumentationObject externalDocs) {
+                        return new MethodObject(values.withPrintable(new NamedPrintable("externalDocs", externalDocs)));
+                    }
+
+                    @Override
+                    public final <T extends Media<T>> T printOn(final T media) {
+                        return values.printOn(media);
+                    }
+
+                    public enum MethodObjectParamStructure {
+                        byposition("by-position"),
+                        byname("by-name"),
+                        either("either");
+
+                        private final String value;
+
+                        private MethodObjectParamStructure(final String value) {
+                            this.value = value;
+                        }
+
+                        @Override
+                        public String toString() {
+                            return value;
+                        }
+
+                    }
+                }
+                """
+            )
+        );
+    }
+
     private String generateOpenRPCSpecClassWithName(final String clsName) throws IOException {
         final StringWriter writer = new StringWriter();
         new CodeGenerator(


### PR DESCRIPTION
the current implemention uses the title to create the alternative wrapper. for the result of the method the title is "methodObjectResult", but the alternatives are ContentDescriptor and Reference which are the same as ContentDescriptorOrReference from e.g. params. The new structure allow to define ONE instance and use them as param and result.